### PR TITLE
Fstab; Fix otg file system & disable sdcard1.

### DIFF
--- a/rootdir/root/fstab.qcom
+++ b/rootdir/root/fstab.qcom
@@ -11,5 +11,5 @@
 /dev/block/bootdevice/by-name/misc           /misc        emmc    defaults                                                    defaults
 /dev/block/bootdevice/by-name/modem          /firmware    vfat    ro,shortname=lower,uid=1000,gid=1026,dmask=227,fmask=337,context=u:object_r:firmware_file:s0    wait
 
-/devices/soc.0/7864900.sdhci/mmc_host        auto         auto    defaults                                                    voldmanaged=sdcard1:auto,noemulatedsd
-/devices/platform/msm_hsusb_host/usb1        /storage/usbotg vfat nosuid,nodev                                                wait,voldmanaged=usbotg:auto
+#/devices/soc.0/7864900.sdhci/mmc_host        auto         auto    defaults                                                    voldmanaged=sdcard1:auto,noemulatedsd
+/devices/platform/msm_hsusb_host/usb1        auto         auto    defaults                                                    voldmanaged=usbotg:auto


### PR DESCRIPTION
Auto-detect otg file system;
Disable useless sdcard1. We don't have sd slot. (Set as original kernel)

Now otg should work as it's supposed to, with any file system supported by kernel.
